### PR TITLE
Update Sphinx configuration to disable relative URLs

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -45,6 +45,7 @@ html_title = f"{project} {release}"
 # GitHub Pages configuration
 html_baseurl = "https://2phi.github.io/weac/"
 html_use_index = True
+html_use_relative_urls = False
 
 # Theme options for sphinxawesome_theme
 html_theme_options = {


### PR DESCRIPTION
- Set `html_use_relative_urls` to `False` to ensure absolute URLs are used in the documentation.
- This change enhances the clarity and accessibility of links in the generated documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docs build to generate absolute URLs for all links in the HTML output.
  * Improves navigation consistency when viewing documentation across different hosting contexts (including GitHub Pages).
  * No changes to site indexing or base URL settings.
  * No impact on application runtime or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->