### PR TITLE
Bump version: 2.6.4 → 3.0.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 - family-names: "Weissgraeber"
   given-names: "Philipp"
   orcid: "https://orcid.org/0000-0001-8320-8672"
-version: 2.6.4
+version: 3.0.0
 date-released: 2021-12-30
 identifiers:
   - description: Collection of archived snapshots of all versions of WEAC

--- a/demo/demo.ipynb
+++ b/demo/demo.ipynb
@@ -13,7 +13,7 @@
    "id": "695bafcb",
    "metadata": {},
    "source": [
-    "Note that instructions in this notebook refer to **release v2.6.4.** Please make sure you are running the latest version of weac using\n",
+    "Note that instructions in this notebook refer to **release v3.0.0.** Please make sure you are running the latest version of weac using\n",
     "\n",
     "```bash\n",
     "pip install -U weac\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "weac"
-version = "2.6.4"
+version = "3.0.0"
 authors = [
     {name = "2phi GbR", email = "mail@2phi.de"},
 ]
@@ -122,7 +122,7 @@ ignore = [
 ]
 
 [tool.bumpversion]
-current_version = "2.6.4"
+current_version = "3.0.0"
 tag = true
 commit = true
 

--- a/weac/__init__.py
+++ b/weac/__init__.py
@@ -2,4 +2,4 @@
 WEAC - Weak Layer Anticrack Nucleation Model
 """
 
-__version__ = "2.6.4"
+__version__ = "3.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Enhanced citation metadata: added project URL, multiple DOIs for archived releases, and a preferred citation to the related The Cryosphere article.
  * Updated demo instructions to reference version 3.0.0.

* Chores
  * Bumped release version to 3.0.0 and synchronized version references across the project.
  * Adjusted release automation configuration to track relevant files only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->