### PR TITLE
Test Generalized Backend + Minor Updates

### DIFF
--- a/src/weac/components/layer.py
+++ b/src/weac/components/layer.py
@@ -239,7 +239,7 @@ class WeakLayer(BaseModel):
     G : float, optional
         Shear modulus G [MPa].  If omitted it is derived from ``E`` and ``nu``.
     kn : float, optional
-        Normal (compression) spring stiffness kₙ [N mm⁻³].  If omitted it is
+        Normal (compression) spring stiffness kₙ [N mm⁻³].  If omitted is
         computed as ``E_plane / t`` where
         ``E_plane = E / (1 - nu²)``.
     kt : float, optional


### PR DESCRIPTION
## Further Tasks for Generalized Backend

**Missing:**
- config clarification of f (two descriptions available) (-> src/weac/components/layer.py)
- no Tests for generalized mode (-> tests/...)
- Double Gi/Gii/Gii implementation with **one commented out**, should remove one (-> src/weac/core/generalized_field_quanitites.py)

**Clarifications** @Flo-rhein
- **f**: In file src/weac/components/layer.py on lines 233 /257 we have two descriptions. Which one of the two is the correct description? resultant force or weight density?
- **Two implementations**: In Generalized Quantities there are two implementations for Gi/Gii/Giii. Can we remove the comments or is there a reason to keep these in.
- **Tests**: Utility Tests + Regression Tests are required, showing, verifying that the structures returned by the generalized backend still work with the criteria evaluator. Also regression tests help breaking changes in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor improvements to code documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->